### PR TITLE
Update anchor auto formatting

### DIFF
--- a/src/autoanchor.js
+++ b/src/autoanchor.js
@@ -194,7 +194,8 @@ export default class AutoAnchor extends Plugin {
 		model.enqueueChange( writer => {
 			const defaultProtocol = this.editor.config.get( 'anchor.defaultProtocol' );
 			const parsedUrl = addAnchorProtocolIfApplicable( anchor, defaultProtocol );
-			writer.setAttribute( 'anchorId', parsedUrl, range );
+      // Create a link to an anchor with the parsed value.
+			writer.setAttribute( 'linkHref', parsedUrl, range );
 		} );
 	}
 }

--- a/src/autoanchor.js
+++ b/src/autoanchor.js
@@ -14,39 +14,13 @@ import { addAnchorProtocolIfApplicable } from './utils';
 
 const MIN_LINK_LENGTH_WITH_SPACE_AT_END = 4; // Ie: "t.co " (length 5).
 
-// This was a tweak from https://gist.github.com/dperini/729294.
 const URL_REG_EXP = new RegExp(
 	// Group 1: Line start or after a space.
 	'(^|\\s)' +
-	// Group 2: Detected URL (or e-mail).
-	'(' +
-		// Protocol identifier or short syntax "//"
-		// a. Full form http://user@foo.bar.baz:8080/foo/bar.html#baz?foo=bar
-		'(' +
-			'(?:(?:(?:https?|ftp):)?\\/\\/)' +
-			// BasicAuth using user:pass (optional)
-			'(?:\\S+(?::\\S*)?@)?' +
-			'(?:' +
-				// Host & domain names.
-				'(?![-_])(?:[-\\w\\u00a1-\\uffff]{0,63}[^-_]\\.)+' +
-				// TLD identifier name.
-				'(?:[a-z\\u00a1-\\uffff]{2,})' +
-			')' +
-			// port number (optional)
-			'(?::\\d{2,5})?' +
-			// resource path (optional)
-			'(?:[/?#]\\S*)?' +
-		')' +
-		'|' +
-		// b. Short form (either www.example.com or example@example.com)
-		'(' +
-			'(www.|(\\S+@))' +
-			// Host & domain names.
-			'((?![-_])(?:[-\\w\\u00a1-\\uffff]{0,63}[^-_]\\.))+' +
-	// TLD identifier name.
-	'(?:[a-z\\u00a1-\\uffff]{2,})' +
-	')' +
-	')$', 'i' );
+	// Group 2: Detected anchor (begin with #, follows HTML5 restrictions on
+  // allowed values).
+	'(#\\S+)'
+);
 
 const URL_GROUP_IN_MATCH = 2;
 


### PR DESCRIPTION
I updated the regex to only match anchors (beginning with `#`), since Drupal already handles auto formatting URLs and emails. The regex matches against HTML5 requirements for ids (which is essentially any character except spaces). There is a more complicated regex for the stricter HTML4 requirements, if you'd prefer to use that.

I also changed the output of the auto formatting. Instead of creating link that was an anchor whose id was the typed value I made a link _to_ an anchor with the typed value. This reflects the way hashes typically behave on social media so would probably be the expected behavior of users.

See https://www.drupal.org/project/anchor_link/issues/3391120