### PR TITLE
Add back `name` attribute

### DIFF
--- a/src/anchorcommand.js
+++ b/src/anchorcommand.js
@@ -190,6 +190,7 @@ export default class AnchorCommand extends Command {
 				else if ( id !== '' ) {
 					const attributes = toMap( selection.getAttributes() );
 					attributes.set('id', id);
+					attributes.set('name', id);
 
 					truthyManualDecorators.forEach( item => {
 						attributes.set( item, true );

--- a/src/anchorediting.js
+++ b/src/anchorediting.js
@@ -80,7 +80,7 @@ export default class AnchorEditing extends Plugin {
 			allowContentOf: '$inlineObject',
 			allowWhere: '$inlineObject',
 			inheritTypesFrom: '$inlineObject',
-			allowAttributes: [ 'class', 'id' ]
+			allowAttributes: [ 'class', 'id', 'name' ]
 		});
 
 		editor.conversion.for( 'dataDowncast' )

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,7 +45,7 @@ export function isAnchorElement( node ) {
  */
 export function createAnchorElement( id, { writer } ) {
 	// Priority 5 - https://github.com/ckeditor/ckeditor5-anchor/issues/121.
-	const anchorElement = writer.createAttributeElement( 'a', { id }, { priority: 5 } );
+	const anchorElement = writer.createAttributeElement( 'a', { id, name: id }, { priority: 5 } );
 	writer.addClass("ck-anchor", anchorElement);
 	writer.setCustomProperty( 'anchor', true, anchorElement );
 
@@ -61,7 +61,7 @@ export function createAnchorElement( id, { writer } ) {
  */
 export function createEmptyAnchorElement( id, { writer } ) {
 	let anchorElement = null;
-	anchorElement = writer.createEmptyElement( 'a', { id });
+	anchorElement = writer.createEmptyElement( 'a', { id, name: id });
 
 	writer.addClass("ck-anchor", anchorElement);
 	writer.setCustomProperty( 'anchor', true, anchorElement );
@@ -77,7 +77,7 @@ export function createEmptyAnchorElement( id, { writer } ) {
  * @returns {module:engine/view/emptyelement~EmptyElement}
  */
 export function createEmptyPlaceholderAnchorElement( id, { writer } ) {
-	const anchorElement = writer.createRawElement('span', { id }, function (domDocument) {
+	const anchorElement = writer.createRawElement('span', { id, name: id }, function (domDocument) {
        domDocument.innerHTML = `[INVISIBLE ANCHOR: ${id}]`;
     });
     writer.addClass("ck-anchor", anchorElement);


### PR DESCRIPTION
As much as I'd also like to deprecate name attribute, we cannot do so as it leads to data loss.

Ideally existing data would have created duplicate anchor tags with both ID and name attributes, i.e. `<a href name>`. However due to previous configuration, or data import/migration existing anchor tags may only have a `name` attribute. When using release 0.3.0 with the commit dd9358fe, this causes the CKE5 configuration to remove name from allowed attributes, leading to data loss on save. Anchors will be rendered inoperable since there was no `id` attribute.

My best suggestion is to de-deprecate the name attribute by reverting the commit.

------

> Revert "Remove use of deprecated `name` attribute"
> This reverts commit dd9358fe05c402c2efbe18e98867e7f1276e468f.