### PR TITLE
Avoid turning actual links into anchors

### DIFF
--- a/src/anchorediting.js
+++ b/src/anchorediting.js
@@ -113,7 +113,8 @@ export default class AnchorEditing extends Plugin {
 				view: {
 					name: 'a',
 					attributes: {
-						id: true
+						id: true,
+						href: false
 					}
 				},
 				model: {


### PR DESCRIPTION
This attempts to prevent actual links from inadvertently becoming anchors by specifying `href: false` to limit `<a>` elements [qualifying for conversion](https://ckeditor.com/docs/ckeditor5/latest/framework/deep-dive/conversion/helpers/upcast.html#using-view-element-definition).

Without this, I encountered instances where adding a link with an ID in Source Editing mode like `<a href="https://google.com" id="someId">Click here</a>` would automatically be turned into an anchor link with `class="ck-anchor"` upon returning to the WYSIWYG editing mode.

See https://www.drupal.org/project/anchor_link/issues/3394328