### PR TITLE
Allow invisible anchors to be edited and deleted

### DIFF
--- a/src/anchorcommand.js
+++ b/src/anchorcommand.js
@@ -207,6 +207,12 @@ export default class AnchorCommand extends Command {
 				[ 'anchorId', ...truthyManualDecorators, ...falsyManualDecorators ].forEach( item => {
 					writer.removeSelectionAttribute( item );
 				} );
+			} else if (selection.getSelectedElement()?.name === 'anchor') {
+				// Replace an invisible anchor.
+				const anchor = writer.createElement('anchor', {
+					anchorId: id
+				});
+				model.insertObject(anchor, null, null, { setSelection: 'on' });
 			} else {
 				// If selection has non-collapsed ranges, we change attribute on nodes inside those ranges
 				// omitting nodes where the `anchorId` attribute is disallowed.

--- a/src/anchorcommand.js
+++ b/src/anchorcommand.js
@@ -189,7 +189,7 @@ export default class AnchorCommand extends Command {
 				// So, if `id` is empty, do not create text node.
 				else if ( id !== '' ) {
 					const attributes = toMap( selection.getAttributes() );
-					attributes.set('id', id);
+					attributes.set('anchorId', id);
 
 					truthyManualDecorators.forEach( item => {
 						attributes.set( item, true );

--- a/src/anchorediting.js
+++ b/src/anchorediting.js
@@ -83,14 +83,20 @@ export default class AnchorEditing extends Plugin {
 			allowAttributes: [ 'class', 'id', 'anchorId' ]
 		});
 
-		// editor.conversion.for( 'dataDowncast' )
-		// 	.attributeToElement( { model: 'anchorId', view: createAnchorElement } );
-		// editor.conversion.for('dataDowncast').elementToElement({
-		// 	model: 'anchor',
-		// 	view: (modelItem, viewWriter) => {
-		// 		return createEmptyAnchorElement( modelItem.getAttribute('id'), viewWriter);
-		// 	}
-		// });
+		editor.conversion.for( 'dataDowncast' )
+			.attributeToElement( {
+				model: {
+					name: '$text',
+					key: 'anchorId',
+				},
+				view: createAnchorElement,
+			});
+		editor.conversion.for('dataDowncast').elementToElement({
+			model: 'anchor',
+			view: (modelItem, viewWriter) => {
+				return createEmptyAnchorElement( modelItem.getAttribute('anchorId'), viewWriter);
+			}
+		});
 
 		editor.conversion.for( 'editingDowncast' )
 			.attributeToElement( { model: 'anchorId', view: ( id, conversionApi ) => {

--- a/src/anchorediting.js
+++ b/src/anchorediting.js
@@ -18,7 +18,7 @@ import UnanchorCommand from './unanchorcommand';
 import ManualDecorator from './utils/manualdecorator';
 import findAttributeRange from '@ckeditor/ckeditor5-typing/src/utils/findattributerange';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
-import { viewToModelPositionOutsideModelElement } from '@ckeditor/ckeditor5-widget';
+import { viewToModelPositionOutsideModelElement } from "ckeditor5/src/widget";
 
 import {
 	createAnchorElement,

--- a/src/anchorediting.js
+++ b/src/anchorediting.js
@@ -80,17 +80,17 @@ export default class AnchorEditing extends Plugin {
 			allowContentOf: '$inlineObject',
 			allowWhere: '$inlineObject',
 			inheritTypesFrom: '$inlineObject',
-			allowAttributes: [ 'class', 'id' ]
+			allowAttributes: [ 'class', 'id', 'anchorId' ]
 		});
 
-		editor.conversion.for( 'dataDowncast' )
-			.attributeToElement( { model: 'anchorId', view: createAnchorElement } );
-		editor.conversion.for('dataDowncast').elementToElement({
-			model: 'anchor',
-			view: (modelItem, viewWriter) => {
-				return createEmptyAnchorElement( modelItem.getAttribute('id'), viewWriter);
-			}
-		});
+		// editor.conversion.for( 'dataDowncast' )
+		// 	.attributeToElement( { model: 'anchorId', view: createAnchorElement } );
+		// editor.conversion.for('dataDowncast').elementToElement({
+		// 	model: 'anchor',
+		// 	view: (modelItem, viewWriter) => {
+		// 		return createEmptyAnchorElement( modelItem.getAttribute('id'), viewWriter);
+		// 	}
+		// });
 
 		editor.conversion.for( 'editingDowncast' )
 			.attributeToElement( { model: 'anchorId', view: ( id, conversionApi ) => {
@@ -104,7 +104,7 @@ export default class AnchorEditing extends Plugin {
 		editor.conversion.for('editingDowncast').elementToElement({
 			model: 'anchor',
 			view: (modelItem, viewWriter) => {
-				return createEmptyPlaceholderAnchorElement( modelItem.getAttribute('id'), viewWriter, true);
+				return createEmptyPlaceholderAnchorElement( modelItem.getAttribute('anchorId'), viewWriter, true);
 			}
 		});
 
@@ -133,7 +133,7 @@ export default class AnchorEditing extends Plugin {
 				view: {
 					name: 'a',
 					attributes: {
-						id: true
+						id: true,
 					}
 				},
 				model: ( viewElement, { writer } ) => {
@@ -141,7 +141,7 @@ export default class AnchorEditing extends Plugin {
 						return;
 					}
 
-					return writer.createElement( 'anchor', { id: viewElement.getAttribute('id') } );
+					return writer.createElement( 'anchor', { anchorId: viewElement.getAttribute('id') } );
 				}
 			} );
 

--- a/src/anchorediting.js
+++ b/src/anchorediting.js
@@ -18,6 +18,8 @@ import UnanchorCommand from './unanchorcommand';
 import ManualDecorator from './utils/manualdecorator';
 import findAttributeRange from '@ckeditor/ckeditor5-typing/src/utils/findattributerange';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
+import { viewToModelPositionOutsideModelElement } from '@ckeditor/ckeditor5-widget';
+
 import {
 	createAnchorElement,
 	createEmptyAnchorElement, createEmptyPlaceholderAnchorElement,
@@ -178,6 +180,11 @@ export default class AnchorEditing extends Plugin {
 
 		// Handle removing the content after the anchor element.
 		this._handleDeleteContentAfterAnchor();
+
+		editor.editing.mapper.on(
+			'viewToModelPosition',
+			viewToModelPositionOutsideModelElement( editor.model, viewElement => viewElement.hasClass( 'ck-anchor-placeholder' ) )
+		);
 	}
 
 	/**

--- a/src/unanchorcommand.js
+++ b/src/unanchorcommand.js
@@ -76,6 +76,11 @@ export default class UnanchorCommand extends Command {
 					}
 				}
 			}
+
+			// Remove an invisible anchor.
+			if (selection.getSelectedElement()?.name === 'anchor') {
+				model.deleteContent(selection);
+			}
 		} );
 	}
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,7 @@
  */
 
 import { upperFirst } from 'lodash-es';
-import { toWidget } from '@ckeditor/ckeditor5-widget';
+import { toWidget } from "ckeditor5/src/widget";
 
 const ATTRIBUTE_WHITESPACES = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205f\u3000]/g; // eslint-disable-line no-control-regex
 const SAFE_URL = /^(?:(?:https?|ftps?|mailto):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i;

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,7 +80,7 @@ export function createEmptyAnchorElement( id, { writer } ) {
 export function createEmptyPlaceholderAnchorElement( anchorId, { writer } ) {
 	const anchorElement = writer.createContainerElement('span', {
 		class: 'ck-anchor-placeholder',
-	}, [writer.createText(`[INVISIBLE ANCHOR: ${anchorId}]`)]);
+	}, [writer.createText(`#${anchorId}`)]);
 	return toWidget(anchorElement, writer );
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,6 +8,7 @@
  */
 
 import { upperFirst } from 'lodash-es';
+import { toWidget } from '@ckeditor/ckeditor5-widget';
 
 const ATTRIBUTE_WHITESPACES = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205f\u3000]/g; // eslint-disable-line no-control-regex
 const SAFE_URL = /^(?:(?:https?|ftps?|mailto):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i;
@@ -64,6 +65,7 @@ export function createEmptyAnchorElement( id, { writer } ) {
 	anchorElement = writer.createEmptyElement( 'a', { id });
 
 	writer.addClass("ck-anchor", anchorElement);
+	writer.addClass("foo", anchorElement);
 	writer.setCustomProperty( 'anchor', true, anchorElement );
 
 	return anchorElement;
@@ -72,18 +74,13 @@ export function createEmptyAnchorElement( id, { writer } ) {
 /**
  * Creates an SVG placeholder {@link module:engine/view/emptyelement~EmptyElement} with the provided `id` attribute.
  *
- * @param {String} id
+ * @param {String} anchorId
  * @param {module:engine/conversion/downcastdispatcher~DowncastConversionApi} conversionApi
  * @returns {module:engine/view/emptyelement~EmptyElement}
  */
-export function createEmptyPlaceholderAnchorElement( id, { writer } ) {
-	const anchorElement = writer.createRawElement('span', { id }, function (domDocument) {
-       domDocument.innerHTML = `[INVISIBLE ANCHOR: ${id}]`;
-    });
-    writer.addClass("ck-anchor", anchorElement);
-	writer.setCustomProperty( 'anchor', true, anchorElement );
-
-	return anchorElement;
+export function createEmptyPlaceholderAnchorElement( anchorId, { writer } ) {
+	const anchorElement = writer.createContainerElement('span', {}, [writer.createText(`[INVISIBLE ANCHOR: ${anchorId}]`)]);
+	return toWidget(anchorElement, writer );
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,7 +78,9 @@ export function createEmptyAnchorElement( id, { writer } ) {
  * @returns {module:engine/view/emptyelement~EmptyElement}
  */
 export function createEmptyPlaceholderAnchorElement( anchorId, { writer } ) {
-	const anchorElement = writer.createContainerElement('span', {}, [writer.createText(`[INVISIBLE ANCHOR: ${anchorId}]`)]);
+	const anchorElement = writer.createContainerElement('span', {
+		class: 'ck-anchor-placeholder',
+	}, [writer.createText(`[INVISIBLE ANCHOR: ${anchorId}]`)]);
 	return toWidget(anchorElement, writer );
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,7 +80,7 @@ export function createEmptyAnchorElement( id, { writer } ) {
 export function createEmptyPlaceholderAnchorElement( anchorId, { writer } ) {
 	const anchorElement = writer.createContainerElement('span', {
 		class: 'ck-anchor-placeholder',
-	}, [writer.createText(`#${anchorId}`)]);
+	}, [writer.createText(`[INVISIBLE ANCHOR: ${anchorId}]`)]);
 	return toWidget(anchorElement, writer );
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,7 +65,6 @@ export function createEmptyAnchorElement( id, { writer } ) {
 	anchorElement = writer.createEmptyElement( 'a', { id });
 
 	writer.addClass("ck-anchor", anchorElement);
-	writer.addClass("foo", anchorElement);
 	writer.setCustomProperty( 'anchor', true, anchorElement );
 
 	return anchorElement;

--- a/theme/anchor.css
+++ b/theme/anchor.css
@@ -8,3 +8,8 @@
  * it acts as a message to the builder telling that it should look for the corresponding styles
  * **in the theme** when compiling the editor.
  */
+.ck-anchor-placeholder {
+    color: dimgrey;
+    font-style: italic;
+    padding-inline: 0.25rem;
+}

--- a/theme/anchor.css
+++ b/theme/anchor.css
@@ -8,8 +8,3 @@
  * it acts as a message to the builder telling that it should look for the corresponding styles
  * **in the theme** when compiling the editor.
  */
-.ck-anchor-placeholder {
-    color: dimgrey;
-    font-style: italic;
-    padding-inline: 0.25rem;
-}


### PR DESCRIPTION
Uses an inline widget as per https://ckeditor.com/docs/ckeditor5/latest/tutorials/widgets/implementing-an-inline-widget.html to allow the anchor to be edited and deleted.

Might be possible to fix in the upstream repo.

https://github.com/northernco/ckeditor5-anchor-drupal/assets/665110/10de54ab-43c7-4dca-9257-e4d4755dadc7
