### PR TITLE
Anchors possibly not working

### DIFF
--- a/sample/index.html
+++ b/sample/index.html
@@ -26,6 +26,15 @@
         <code>Anchor</code> inserts text into the editor. You can click the CKEditor 5 icon in the toolbar and see the results.
     </p>
 
+    <h3>Anchor Tests</h3>
+    <h4><a name="nameonlyanchor1">Name Only Anchor</a></h4>
+    <h4><a name="nameonlyanchor"></a> Name Only Invisible Anchor</h4>
+    <h4><a id="idonlyanchor1">ID Only Anchor</a></h4>
+    <h4><a id="idonlyanchor"></a> ID Only Invisible Anchor</h4>
+    <h4><a name="nameandidanchor" id="nameandidanchor"></a> Name and ID Invisible Anchor</h4>
+    <h4><a name="nameandidanchor1" id="nameandidanchor1">Name and ID Anchor</a></h4>
+    <h4><a class="ck-anchor" id="idandclassanchor">Name and ID Anchor with class</a></h4>
+
     <h3>Helpful resources</h3>
     <ul>
         <li>Architecture

--- a/src/anchorediting.js
+++ b/src/anchorediting.js
@@ -122,7 +122,6 @@ export default class AnchorEditing extends Plugin {
 					name: 'a',
 					attributes: {
 						id: true,
-						href: false
 					}
 				},
 				model: {

--- a/src/anchorediting.js
+++ b/src/anchorediting.js
@@ -131,6 +131,10 @@ export default class AnchorEditing extends Plugin {
 							return;
 						}
 
+						if (viewElement.hasAttribute('href')) {
+							return;
+						}
+
 						return viewElement.getAttribute( 'id' );
 					}
 				}


### PR DESCRIPTION
**Steps to Reproduce**
1. Copy (or merge) anchor tests from commit 9ec7d26 to the `sample/index.html`
2. Run `npm run start`

**Expected Results**
All the test anchors except "Name Only Anchor" and "Name Only Invisible Anchor" would have the anchor flag and be editable.

**Actual Results**
Only the two Invisible anchors with ids are editable. I also seem to have the same result in my Drupal instance.

**Proposed Resolution**
Remove line 125 in `src/anchorediting.js` (commit 5119d4b).  This seems to fix the problem both in the sample/index.html dev environment and also on our Drupal.  But I'm not super confident in this solution, or if this is a problem others are seeing.  I found this as part of trying to add support for legacy code with anchors that only have a name attribute. I will be posting another merge request for that one.