### PR TITLE
Add support for anchors with only a name attribute

### DIFF
--- a/sample/index.html
+++ b/sample/index.html
@@ -26,6 +26,15 @@
         <code>Anchor</code> inserts text into the editor. You can click the CKEditor 5 icon in the toolbar and see the results.
     </p>
 
+    <h3>Anchor Tests</h3>
+    <h4><a name="nameonlyanchor1">Name Only Anchor</a></h4>
+    <h4><a name="nameonlyanchor"></a> Name Only Invisible Anchor</h4>
+    <h4><a id="idonlyanchor1">ID Only Anchor</a></h4>
+    <h4><a id="idonlyanchor"></a> ID Only Invisible Anchor</h4>
+    <h4><a name="nameandidanchor" id="nameandidanchor"></a> Name and ID Invisible Anchor</h4>
+    <h4><a name="nameandidanchor1" id="nameandidanchor1">Name and ID Anchor</a></h4>
+    <h4><a class="ck-anchor" id="idandclassanchor">Name and ID Anchor with class</a></h4>
+
     <h3>Helpful resources</h3>
     <ul>
         <li>Architecture

--- a/src/anchorediting.js
+++ b/src/anchorediting.js
@@ -82,7 +82,7 @@ export default class AnchorEditing extends Plugin {
 			allowContentOf: '$inlineObject',
 			allowWhere: '$inlineObject',
 			inheritTypesFrom: '$inlineObject',
-			allowAttributes: [ 'class', 'id', 'anchorId' ]
+			allowAttributes: [ 'class', 'id', 'anchorId', 'name' ]
 		});
 
 		editor.conversion.for( 'dataDowncast' )
@@ -136,6 +136,26 @@ export default class AnchorEditing extends Plugin {
 					}
 				}
 			} );
+		
+		editor.conversion.for( 'upcast' )
+			.elementToAttribute( {
+				view: {
+					name: 'a',
+					attributes: {
+						name: true,
+					}
+				},
+				model: {
+					key: 'anchorId',
+					value: viewElement => {
+						if (viewElement.childCount < 1) {
+							return;
+						}
+
+						return viewElement.getAttribute( 'name' );
+					}
+				}
+			} );
 
 		editor.conversion.for( 'upcast' )
 			.elementToElement( {
@@ -151,6 +171,23 @@ export default class AnchorEditing extends Plugin {
 					}
 
 					return writer.createElement( 'anchor', { anchorId: viewElement.getAttribute('id') } );
+				}
+			} );
+		
+		editor.conversion.for( 'upcast' )
+			.elementToElement( {
+				view: {
+					name: 'a',
+					attributes: {
+						name: true
+					}
+				},
+				model: ( viewElement, { writer } ) => {
+					if (viewElement.childCount > 0) {
+						return;
+					}
+
+					return writer.createElement( 'anchor', { anchorId: viewElement.getAttribute('name') } );
 				}
 			} );
 


### PR DESCRIPTION
We have quite a bit of legacy code that has empty anchors that only have a `name` attribute, and would like these to show up as editable anchors in ckeditor in Drupal, like this:

`<a name="some-anchor"></a>`

This is in the same vein as [pull request #3 ](https://github.com/northernco/ckeditor5-anchor-drupal/pull/3), except I don't care if the name attribute is preserved. I just care that I can edit the anchor easily in ckeditor5 in Drupal, and that it works after I save.

In pull request #3, there is discussion of whether this functionality should be allowed or if the name attribute should be transformed to ids first.  I'm not sure if my MR code is the best way to address this issue, or if it even should be changed. However, this seems to work for me both on the `sample/index.html` dev environment, and in our Drupal instance.