### PR TITLE
Only apply autolink immediately after detected anchor

### DIFF
--- a/src/autoanchor.js
+++ b/src/autoanchor.js
@@ -19,7 +19,7 @@ const URL_REG_EXP = new RegExp(
 	'(^|\\s)' +
 	// Group 2: Detected anchor (begin with #, follows HTML5 restrictions on
   // allowed values).
-	'(#\\S+)'
+	'(#\\S+)$'
 );
 
 const URL_GROUP_IN_MATCH = 2;


### PR DESCRIPTION
When an anchor is detected within a line of text, it was being applied even when the added space was not at the end of it. This put it in the wrong place, and made it nearly impossible to include text like a hashtag in content without being a link. See video for broken behaviour:


https://github.com/user-attachments/assets/7c3982e1-fc9f-4706-afaa-09cfffa4537e

I can well imagine a different solution is appropriate, but hopefully that video at least demonstrates the issue that needs solving!