### PR TITLE
Include name attribute

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -46,7 +46,7 @@ export function isAnchorElement( node ) {
  */
 export function createAnchorElement( id, { writer } ) {
 	// Priority 5 - https://github.com/ckeditor/ckeditor5-anchor/issues/121.
-	const anchorElement = writer.createAttributeElement( 'a', { id }, { priority: 5 } );
+	const anchorElement = writer.createAttributeElement( 'a', { id, name: id }, { priority: 5 } );
 	writer.addClass("ck-anchor", anchorElement);
 	writer.setCustomProperty( 'anchor', true, anchorElement );
 
@@ -62,7 +62,7 @@ export function createAnchorElement( id, { writer } ) {
  */
 export function createEmptyAnchorElement( id, { writer } ) {
 	let anchorElement = null;
-	anchorElement = writer.createEmptyElement( 'a', { id });
+	anchorElement = writer.createEmptyElement( 'a', { id, name: id });
 
 	writer.addClass("ck-anchor", anchorElement);
 	writer.setCustomProperty( 'anchor', true, anchorElement );


### PR DESCRIPTION
Though name is deprecated, including it in the dataDowncast and the resulting source will support backward compatibility with CKEditor 4 anchor links. Full rationale for this is detailed in:
- [This comment] on issue [Support the "name" attribute for backwards compatibility [#3399656] | Drupal.org](https://www.drupal.org/project/anchor_link/issues/3399656#comment-15840197), and
- [Support concurrent use of CKEditor 4 and 5 [#3484756] | Drupal.org](https://www.drupal.org/project/anchor_link/issues/3484756)